### PR TITLE
Version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,15 @@
 Benchmark and load test MS SQL Server.
 
 ## Example Usage
-```
+```bash
 SQLDriver -r 5 -t 10 -c "server=localhost;initial catalog=master;integrated security=SSPI" -s "select @@servername"
 
 SQLDriver -r 5 -t 10 -c "server=localhost;initial catalog=master;integrated security=SSPI" -s "select @@servername" -o "c:\results.csv"
+
+# Or if you run from source
+# Note the double-hyphens
+cd ./src
+dotnet run --r 5 --t 10 --c "server=localhost;initial catalog=master;integrated security=SSPI" --s "select @@servername"
 ```
 
 Both of these commands will:

--- a/src/SQLDriver.csproj
+++ b/src/SQLDriver.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-    <LangVersion>7.2</LangVersion>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.3.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.5.1" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Targets 3.1, and bumps SQLClient to 4.8.1.

The experiment to move to DragonFruit was abandoned after it turned out the code wouldn't end up that much (any?) more concise. 